### PR TITLE
redefining mc_lambda as in paper, passing variables to tracker

### DIFF
--- a/strong_sort/configs/strong_sort.yaml
+++ b/strong_sort/configs/strong_sort.yaml
@@ -1,6 +1,6 @@
 STRONGSORT:
   ECC: True              # activate camera motion compensation
-  MC_LAMBDA: 0.995       # matching with both appearance (1 - MC_LAMBDA) and motion cost
+  MC_LAMBDA: 0.995       # matching with both appearance (MC_LAMBDA) and motion (1-MC_LAMBDA) cost
   EMA_ALPHA: 0.9         # updates  appearance  state in  an exponential moving average manner
   MAX_DIST: 0.2          # The matching threshold. Samples with larger distance are considered an invalid match
   MAX_IOU_DISTANCE: 0.7  # Gating threshold. Associations with cost larger than this value are disregarded.

--- a/strong_sort/sort/tracker.py
+++ b/strong_sort/sort/tracker.py
@@ -35,12 +35,11 @@ class Tracker:
     """
     GATING_THRESHOLD = np.sqrt(kalman_filter.chi2inv95[4])
 
-    def __init__(self, metric, max_iou_distance=0.9, max_age=30, n_init=3, _lambda=0, ema_alpha=0.9, mc_lambda=0.995):
+    def __init__(self, metric, max_iou_distance=0.9, max_age=30, n_init=3, ema_alpha=0.9, mc_lambda=0.995):
         self.metric = metric
         self.max_iou_distance = max_iou_distance
         self.max_age = max_age
         self.n_init = n_init
-        self._lambda = _lambda
         self.ema_alpha = ema_alpha
         self.mc_lambda = mc_lambda
 
@@ -127,7 +126,7 @@ class Tracker:
         )
         app_gate = app_cost > self.metric.matching_threshold
         # Now combine and threshold
-        cost_matrix = self._lambda * pos_cost + (1 - self._lambda) * app_cost
+        cost_matrix = (1-self.mc_lambda) * pos_cost + self.mc_lambda * app_cost
         cost_matrix[np.logical_or(pos_gate, app_gate)] = linear_assignment.INFTY_COST
         # Return Matrix
         return cost_matrix

--- a/strong_sort/strong_sort.py
+++ b/strong_sort/strong_sort.py
@@ -48,7 +48,7 @@ class StrongSORT(object):
         metric = NearestNeighborDistanceMetric(
             "cosine", self.max_dist, nn_budget)
         self.tracker = Tracker(
-            metric, max_iou_distance=max_iou_distance, max_age=max_age, n_init=n_init)
+            metric, max_iou_distance=max_iou_distance, max_age=max_age, n_init=n_init, ema_alpha=ema_alpha, mc_lambda=mc_lambda)
 
     def update(self, bbox_xywh, confidences, classes, ori_img):
         self.height, self.width = ori_img.shape[:2]


### PR DESCRIPTION
Small PR request to correctly initialize Tracker with mc_lambda, ema_alpha. I don't believe Tracker is initialized anywhere beyond strong_sort.py line 51. 

Note: previously _lambda was used with default 0. This meant the appearance vs motion cost was fully dependent on appearance. Now it is set to 0.995 for appearance (the default in strong_sort.yaml). This means there may be a difference in results after this PR if MC_LAMBDA is not set to 1.0 in the yaml. 