### PR TITLE
Fixes to kalman filter and implementation for adaptive Q and R noise covariance estimation

### DIFF
--- a/strong_sort/sort/kalman_filter.py
+++ b/strong_sort/sort/kalman_filter.py
@@ -114,9 +114,6 @@ class KalmanFilter(object):
             0.1 * mean[3],
             self._std_weight_velocity * mean[3]]
         motion_noise_cov = np.diag(np.square(np.r_[std_pos, std_vel]))
-        
-        chol_factor = scipy.linalg.cho_factor(
-            projected_cov, check_finite=False)
 
         mean = np.dot(self._motion_mat, mean)
         covariance = np.linalg.multi_dot((

--- a/strong_sort/sort/kalman_filter.py
+++ b/strong_sort/sort/kalman_filter.py
@@ -33,9 +33,6 @@ class KalmanFilter(object):
 
     def __init__(self):
         ndim, dt = 4, 1.
-        
-        # Timestamp to keep track of delta time between predictions
-        self._prev_time = 0
 
         # Create Kalman filter model matrices.
         self._motion_mat = np.eye(2 * ndim, 2 * ndim)
@@ -69,8 +66,6 @@ class KalmanFilter(object):
         mean_pos = measurement
         mean_vel = np.zeros_like(mean_pos)
         mean = np.r_[mean_pos, mean_vel]
-        
-        self._prev_time = time.perf_counter()
 
         std = [
             2 * self._std_weight_position * measurement[3],   # the center point x
@@ -100,11 +95,6 @@ class KalmanFilter(object):
             Returns the mean vector and covariance matrix of the predicted
             state. Unobserved velocities are initialized to 0 mean.
         """
-        dt = time.perf_counter() - self._prev_time
-        for i in range(ndim):
-            self._motion_mat[i, ndim + i] = dt
-        self._prev_time = time.perf_counter()
-        
         alpha = 1 + self._initial_error_scaling
         self._initial_error_scaling =
             self._initial_error_scaling * (1-self._initial_noise_dissipation)

--- a/strong_sort/sort/kalman_filter.py
+++ b/strong_sort/sort/kalman_filter.py
@@ -95,9 +95,9 @@ class KalmanFilter(object):
             Returns the mean vector and covariance matrix of the predicted
             state. Unobserved velocities are initialized to 0 mean.
         """
-        alpha = 1 + self._initial_error_scaling
-        self._initial_error_scaling =
-            self._initial_error_scaling * (1-self._initial_noise_dissipation)
+        alpha = 1 + self._initial_noise_scaling
+        self._initial_noise_scaling =
+            self._initial_noise_scaling * (1-self._initial_noise_dissipation)
         std_pos = [
             alpha * self._std_weight_position * mean[3],
             alpha * self._std_weight_position * mean[3],

--- a/strong_sort/sort/kalman_filter.py
+++ b/strong_sort/sort/kalman_filter.py
@@ -32,14 +32,14 @@ class KalmanFilter(object):
     """
 
     def __init__(self):
-        ndim, dt = 4, 1.
+        self.ndim, dt = 4, 1.
 
         # Create Kalman filter model matrices.
-        self._motion_mat = np.eye(2 * ndim, 2 * ndim)
-        for i in range(ndim):
-            self._motion_mat[i, ndim + i] = dt
+        self._motion_mat = np.eye(2 * self.ndim, 2 * self.ndim)
+        for i in range(self.ndim):
+            self._motion_mat[i, self.ndim + i] = dt
 
-        self._update_mat = np.eye(ndim, 2 * ndim)
+        self._update_mat = np.eye(self.ndim, 2 * self.ndim)
 
         # Motion and observation uncertainty are chosen relative to the current
         # state estimate. These weights control the amount of uncertainty in
@@ -79,7 +79,7 @@ class KalmanFilter(object):
         covariance = np.diag(np.square(std))
         return mean, covariance
 
-    def predict(self, mean, covariance):
+    def predict(self, mean, covariance, delta_time=1):
         """Run Kalman filter prediction step.
         Parameters
         ----------
@@ -89,12 +89,17 @@ class KalmanFilter(object):
         covariance : ndarray
             The 8x8 dimensional covariance matrix of the object state at the
             previous time step.
+        delta_time : float
+            The time it took since the last prediction step
         Returns
         -------
         (ndarray, ndarray)
             Returns the mean vector and covariance matrix of the predicted
             state. Unobserved velocities are initialized to 0 mean.
         """
+        for i in range(self.ndim):
+           self._motion_mat[i, self.ndim + i] = delta_time
+        
         alpha = 1 + self._initial_noise_scaling
         self._initial_noise_scaling = \
             self._initial_noise_scaling * (1-self._initial_noise_dissipation)

--- a/strong_sort/sort/kalman_filter.py
+++ b/strong_sort/sort/kalman_filter.py
@@ -71,10 +71,10 @@ class KalmanFilter(object):
         self._prev_time = time.perf_counter()
 
         std = [
-            2 * self._std_weight_position * measurement[3],   # the center point x
-            2 * self._std_weight_position * measurement[3],   # the center point y
+            20 * self._std_weight_position * measurement[3],   # the center point x
+            20 * self._std_weight_position * measurement[3],   # the center point y
             1 * measurement[3],                               # the ratio of width/height
-            2 * self._std_weight_position * measurement[3],   # the height
+            20 * self._std_weight_position * measurement[3],   # the height
             10 * self._std_weight_velocity * measurement[3],
             10 * self._std_weight_velocity * measurement[3],
             0.1 * measurement[3],
@@ -114,6 +114,9 @@ class KalmanFilter(object):
             0.1 * mean[3],
             self._std_weight_velocity * mean[3]]
         motion_noise_cov = np.diag(np.square(np.r_[std_pos, std_vel]))
+        
+        chol_factor = scipy.linalg.cho_factor(
+            projected_cov, check_finite=False)
 
         mean = np.dot(self._motion_mat, mean)
         covariance = np.linalg.multi_dot((

--- a/strong_sort/sort/kalman_filter.py
+++ b/strong_sort/sort/kalman_filter.py
@@ -96,7 +96,7 @@ class KalmanFilter(object):
             state. Unobserved velocities are initialized to 0 mean.
         """
         alpha = 1 + self._initial_noise_scaling
-        self._initial_noise_scaling =
+        self._initial_noise_scaling = \
             self._initial_noise_scaling * (1-self._initial_noise_dissipation)
         std_pos = [
             alpha * self._std_weight_position * mean[3],

--- a/strong_sort/sort/track.py
+++ b/strong_sort/sort/track.py
@@ -246,14 +246,12 @@ class Track:
         self.age += 1
         self.time_since_update += 1
 
-    def predict(self, kf, delta_time=1):
+    def predict(self, delta_time=1):
         """Propagate the state distribution to the current time step using a
         Kalman filter prediction step.
 
         Parameters
         ----------
-        kf : kalman_filter.KalmanFilter
-            The Kalman filter.
         delta_time : float
             The time it took since the last prediction step
 

--- a/strong_sort/sort/track.py
+++ b/strong_sort/sort/track.py
@@ -246,7 +246,7 @@ class Track:
         self.age += 1
         self.time_since_update += 1
 
-    def predict(self, kf):
+    def predict(self, kf, delta_time=1):
         """Propagate the state distribution to the current time step using a
         Kalman filter prediction step.
 
@@ -254,9 +254,12 @@ class Track:
         ----------
         kf : kalman_filter.KalmanFilter
             The Kalman filter.
+        delta_time : float
+            The time it took since the last prediction step
 
         """
-        self.mean, self.covariance = self.kf.predict(self.mean, self.covariance)
+        self.mean, self.covariance = self.kf.predict(
+            self.mean, self.covariance, delta_time)
         self.age += 1
         self.time_since_update += 1
 

--- a/strong_sort/sort/tracker.py
+++ b/strong_sort/sort/tracker.py
@@ -28,8 +28,6 @@ class Tracker:
         Maximum number of missed misses before a track is deleted.
     n_init : int
         Number of frames that a track remains in initialization phase.
-    kf : kalman_filter.KalmanFilter
-        A Kalman filter to filter target trajectories in image space.
     tracks : List[Track]
         The list of active tracks at the current time step.
     """
@@ -44,7 +42,6 @@ class Tracker:
         self.ema_alpha = ema_alpha
         self.mc_lambda = mc_lambda
 
-        self.kf = kalman_filter.KalmanFilter()
         self.tracks = []
         self._next_id = 1
         self._prev_time_step = 0
@@ -70,7 +67,7 @@ class Tracker:
             delta_time = 1
         
         for track in self.tracks:
-            track.predict(self.kf, delta_time)
+            track.predict(delta_time)
 
     def increment_ages(self):
         for track in self.tracks:
@@ -131,7 +128,7 @@ class Tracker:
         msrs = np.asarray([dets[i].to_xyah() for i in detection_indices])
         for row, track_idx in enumerate(track_indices):
             pos_cost[row, :] = np.sqrt(
-                self.kf.gating_distance(
+                tracks[track_idx].kf.gating_distance(
                     tracks[track_idx].mean, tracks[track_idx].covariance, msrs, False
                 )
             ) / self.GATING_THRESHOLD

--- a/strong_sort/sort/tracker.py
+++ b/strong_sort/sort/tracker.py
@@ -47,14 +47,30 @@ class Tracker:
         self.kf = kalman_filter.KalmanFilter()
         self.tracks = []
         self._next_id = 1
+        self._prev_time_step = 0
 
-    def predict(self):
+    def predict(self, time_step=-1):
         """Propagate track state distributions one time step forward.
 
         This function should be called once every time step, before `update`.
+        
+        Parameters
+        ----------
+        time_step : float
+            Time step of the prediction.
         """
+        if self._prev_time_step == 0:
+            self._prev_time_step = time_step
+
+        delta_time = time_step - self._prev_time_step
+        self._prev_time_step = time_step
+        
+        # default to dt = 1 if no time_step was provided
+        if delta_time < 0:
+            delta_time = 1
+        
         for track in self.tracks:
-            track.predict(self.kf)
+            track.predict(self.kf, delta_time)
 
     def increment_ages(self):
         for track in self.tracks:

--- a/strong_sort/strong_sort.py
+++ b/strong_sort/strong_sort.py
@@ -39,7 +39,7 @@ class StrongSORT(object):
         self.tracker = Tracker(
             metric, max_iou_distance=max_iou_distance, max_age=max_age, n_init=n_init)
 
-    def update(self, bbox_xywh, confidences, classes, ori_img):
+    def update(self, bbox_xywh, confidences, classes, ori_img, time_step=-1):
         self.height, self.width = ori_img.shape[:2]
         # generate detections
         features = self._get_features(bbox_xywh, ori_img)
@@ -52,7 +52,7 @@ class StrongSORT(object):
         scores = np.array([d.confidence for d in detections])
 
         # update tracker
-        self.tracker.predict()
+        self.tracker.predict(time_step)
         self.tracker.update(detections, classes, confidences)
 
         # output bbox identities

--- a/track.py
+++ b/track.py
@@ -202,7 +202,8 @@ def run(
 
                 # pass detections to strongsort
                 t4 = time_sync()
-                outputs[i] = strongsort_list[i].update(xywhs.cpu(), confs.cpu(), clss.cpu(), im0)
+                outputs[i] = strongsort_list[i].update(
+                    xywhs.cpu(), confs.cpu(), clss.cpu(), im0, time_sync())
                 t5 = time_sync()
                 dt[3] += t5 - t4
 


### PR DESCRIPTION
Fixed noise covariance matrices so they are not varied based on bounding box location. Fixed delta time of predictions from constant 1 second to varied based on the frequency of predictions, this should increase performance.

Implemented adaptive kalman filter for Q and R estimation, based on
https://arxiv.org/ftp/arxiv/papers/1702/1702.00884.pdf