### PR TITLE
Fix wrong index assignment in byte_tracker.py

### DIFF
--- a/trackers/bytetrack/byte_tracker.py
+++ b/trackers/bytetrack/byte_tracker.py
@@ -194,7 +194,7 @@ class BYTETracker(object):
         scores_second = confs[inds_second]
         
         clss_keep = classes[remain_inds]
-        clss_second = classes[remain_inds]
+        clss_second = classes[inds_second]
         
 
         if len(dets) > 0:


### PR DESCRIPTION
Just a minor fix, unless there is a specific reason why clss_second = classes[remain_inds] and not clss_second = classes[inds_second]