### PR TITLE
Handle conf correctly inside trackers

### DIFF
--- a/track.py
+++ b/track.py
@@ -192,11 +192,12 @@ def run(
                 
                 # draw boxes for visualization
                 if len(outputs[i]) > 0:
-                    for j, (output, conf) in enumerate(zip(outputs[i], det[:, 4])):
+                    for j, (output) in enumerate(outputs[i]):
     
                         bboxes = output[0:4]
                         id = output[4]
                         cls = output[5]
+                        conf = output[6]
 
                         if save_txt:
                             # to MOT format

--- a/trackers/bytetrack/byte_tracker.py
+++ b/trackers/bytetrack/byte_tracker.py
@@ -307,10 +307,11 @@ class BYTETracker(object):
             output.extend(xyxy)
             output.append(tid)
             output.append(t.cls)
+            output.append(t.score)
             outputs.append(output)
 
         return outputs
-
+#track_id, class_id, conf
 
 def joint_stracks(tlista, tlistb):
     exists = {}

--- a/trackers/ocsort/ocsort.py
+++ b/trackers/ocsort/ocsort.py
@@ -92,7 +92,7 @@ class KalmanBoxTracker(object):
         self.hits = 0
         self.hit_streak = 0
         self.age = 0
-        #self.conf = conf
+        self.conf = bbox[-1]
         self.cls = cls
         """
         NOTE: [-1,-1,-1,-1,-1] is a compromising placeholder for non-observation status, the same for the return of 
@@ -317,7 +317,7 @@ class OCSort(object):
                 d = trk.last_observation[:4]
             if (trk.time_since_update < 1) and (trk.hit_streak >= self.min_hits or self.frame_count <= self.min_hits):
                 # +1 as MOT benchmark requires positive
-                ret.append(np.concatenate((d, [trk.id+1], [trk.cls])).reshape(1, -1))
+                ret.append(np.concatenate((d, [trk.id+1], [trk.cls], [trk.conf])).reshape(1, -1))
             i -= 1
             # remove dead tracklet
             if(trk.time_since_update > self.max_age):

--- a/trackers/ocsort/ocsort.py
+++ b/trackers/ocsort/ocsort.py
@@ -111,6 +111,7 @@ class KalmanBoxTracker(object):
         """
         
         if bbox is not None:
+            self.conf = bbox[-1]
             self.cls = cls
             if self.last_observation.sum() >= 0:  # no previous observation
                 previous_box = None


### PR DESCRIPTION
Detections confidence now passed to trackers for internal storage in each track, instead of handling it externally in `track.py`