### PR TITLE
Fix/val on windows

### DIFF
--- a/val.py
+++ b/val.py
@@ -11,7 +11,7 @@ import zipfile
 from pathlib import Path
 import shutil
 import threading
-
+from tqdm import tqdm
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # yolov5 strongsort root directory
@@ -30,52 +30,73 @@ from yolov5.utils.torch_utils import select_device
 from track import run
 
 
-def download_official_mot_eval_tool(dst_val_tools_folder):
+def download_official_mot_eval_tool(val_tools_target_location):
     # source: https://github.com/JonathonLuiten/TrackEval#official-evaluation-code
     val_tools_url = "https://github.com/JonathonLuiten/TrackEval"
     try:
-        Repo.clone_from(val_tools_url, dst_val_tools_folder)
+        Repo.clone_from(val_tools_url, val_tools_target_location)
         LOGGER.info('Official MOT evaluation repo downloaded')
     except git.exc.GitError as err:
         LOGGER.info('Eval repo already downloaded')
         
-def download_mot_dataset(dst_val_tools_folder, benchmark):
-    import wget
-    import ssl
+def download_mot_dataset(val_tools_target_location, benchmark):
 
-    try:
-        _create_unverified_https_context = ssl._create_unverified_context
-    except AttributeError:
-        # Legacy Python that doesn't verify HTTPS certificates by default
-        pass
-    else:
-        # Handle target environment that doesn't support HTTPS verification
-        ssl._create_default_https_context = _create_unverified_https_context
-
-    gt_data_url = 'https://omnomnom.vision.rwth-aachen.de/data/TrackEval/data.zip'
-    if not (dst_val_tools_folder / 'data').is_dir():
-        wget.download(gt_data_url, out=str(dst_val_tools_folder / 'data.zip'))
-        with zipfile.ZipFile(dst_val_tools_folder / 'data.zip', 'r') as zip_ref:
-            zip_ref.extractall(dst_val_tools_folder)
-        os.remove(dst_val_tools_folder / 'data.zip') 
-        LOGGER.info('MOTs ground truth downloaded')
-    else:
-        LOGGER.info('gt already downloaded')
-
-    mot_gt_data_url = 'https://motchallenge.net/data/' + benchmark + '.zip'
-    if not (dst_val_tools_folder / 'data' / benchmark).is_dir():
-        wget.download(mot_gt_data_url, out=str(dst_val_tools_folder / (benchmark + '.zip')))
-        with zipfile.ZipFile(dst_val_tools_folder / (benchmark + '.zip'), 'r') as zip_ref:
-            if opt.benchmark == 'MOT16':
-                zip_ref.extractall(dst_val_tools_folder / 'data' / 'MOT16')
-            else:
-                zip_ref.extractall(dst_val_tools_folder / 'data')
-        os.remove(dst_val_tools_folder / (benchmark + '.zip')) 
-        LOGGER.info(f'{benchmark} images downloaded')
-    else:
-        LOGGER.info(f'{benchmark} data already downloaded')
-        
+    downloaded_flag_file = val_tools_target_location / '.mot_data_downloaded'
     
+    # download and unzip ground truth
+    url = 'https://omnomnom.vision.rwth-aachen.de/data/TrackEval/data.zip'
+    zip_dst = val_tools_target_location / 'data.zip'
+    if not downloaded_flag_file.exists():
+        os.system(f"curl -# -L {url} -o {zip_dst} -# --retry 3 -C -")
+        LOGGER.info(f'data.zip downloaded sucessfully')
+    
+    if zip_dst.exists():
+        try:
+            with zipfile.ZipFile(val_tools_target_location / 'data.zip', 'r') as zip_file:
+                for member in tqdm(zip_file.namelist(), desc=f'Extracting MOT ground truth'):
+                    # extract only if file has not already been extracted
+                    if os.path.exists(val_tools_target_location / member) or os.path.isfile(val_tools_target_location / member):
+                        pass
+                    else:
+                        zip_file.extract(member, val_tools_target_location)
+            LOGGER.info(f'data.zip unzipped sucessfully')
+        except Exception as e:
+            print('data.zip is corrupted. Try deleting the file and run the script again')
+            sys.exit()
+
+    # download and unzip the rest of MOTXX
+    url = 'https://motchallenge.net/data/' + benchmark + '.zip'
+    zip_dst = val_tools_target_location / (benchmark + '.zip')
+    if not downloaded_flag_file.exists():
+        os.system(f"curl -# -L {url} -o {zip_dst} -# --retry 3 -C -")
+        LOGGER.info(f'{benchmark}.zip downloaded sucessfully')
+    
+    if zip_dst.exists():
+        try:
+            with zipfile.ZipFile((val_tools_target_location / (benchmark + '.zip')), 'r') as zip_file:
+                if opt.benchmark == 'MOT16':
+                    # extract only if file has not already been extracted
+                    for member in tqdm(zip_file.namelist(), desc=f'Extracting {benchmark}'):
+                        if os.path.exists(val_tools_target_location / 'data' / 'MOT16' / member) or os.path.isfile(val_tools_target_location / 'data' / 'MOT16' / member):
+                            pass
+                        else:
+                            zip_file.extract(member, val_tools_target_location / 'data' / 'MOT16')
+                else:
+                    for member in tqdm(zip_file.namelist(), desc=f'Extracting {benchmark}'):
+                        if os.path.exists(val_tools_target_location / 'data' / member) or os.path.isfile(val_tools_target_location / 'data' / member):
+                            pass
+                        else:
+                            zip_file.extract(member, val_tools_target_location / 'data')
+            LOGGER.info(f'{benchmark}.zip unzipped successfully')
+            
+            # Create a flag file to indicate that we have already downloaded the dataset
+            with open(downloaded_flag_file, 'w'):
+                pass
+        except Exception as e:
+            print(f'{benchmark}.zip is corrupted. Try deleting the file and run the script again')
+            sys.exit()
+
+
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--yolo-weights', type=str, default=WEIGHTS / 'yolov5m.pt', help='model.pt path(s)')
@@ -111,24 +132,24 @@ def main(opt):
     check_requirements(requirements=ROOT / 'requirements.txt', exclude=('tensorboard', 'thop'))
     
     # download eval files
-    dst_val_tools_folder = ROOT / 'val_utils'
-    download_official_mot_eval_tool(dst_val_tools_folder)
+    val_tools_target_location = ROOT / 'val_utils'
+    download_official_mot_eval_tool(val_tools_target_location)
     
-    if any(opt.benchmark is s for s in ['MOT16', 'MOT17', 'MOT20']):
-        download_mot_dataset(dst_val_tools_folder, opt.benchmark)
+    if any(opt.benchmark == s for s in ['MOT16', 'MOT17', 'MOT20']):
+        download_mot_dataset(val_tools_target_location, opt.benchmark)
     
     # set paths
-    mot_seqs_path = dst_val_tools_folder / 'data' / opt.benchmark / opt.split
+    mot_seqs_path = val_tools_target_location / 'data' / opt.benchmark / opt.split
     
     if opt.benchmark == 'MOT17':
         # each sequences is present 3 times, one for each detector
         # (DPM, FRCNN, SDP). Keep only sequences from  one of them
         seq_paths = sorted([str(p / 'img1') for p in Path(mot_seqs_path).iterdir() if Path(p).is_dir()])
         seq_paths = [Path(p) for p in seq_paths if 'FRCNN' in p]
-        with open(dst_val_tools_folder / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "r") as f:  # 
+        with open(val_tools_target_location / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "r") as f:  # 
             lines = f.readlines()
         # overwrite MOT17 evaluation sequences to evaluate so that they are not duplicated
-        with open(dst_val_tools_folder / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "w") as f:
+        with open(val_tools_target_location / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "w") as f:
             for line in seq_paths:
                 f.write(str(line.parent.stem) + '\n')
     else:
@@ -136,7 +157,7 @@ def main(opt):
         seq_paths = [p / 'img1' for p in Path(mot_seqs_path).iterdir() if Path(p).is_dir()]
     
     save_dir = increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok)  # increment run
-    MOT_results_folder = dst_val_tools_folder / 'data' / 'trackers' / 'mot_challenge' / Path(str(opt.benchmark) + '-' + str(opt.split)) / save_dir.name / 'data'
+    MOT_results_folder = val_tools_target_location / 'data' / 'trackers' / 'mot_challenge' / Path(str(opt.benchmark) + '-' + str(opt.split)) / save_dir.name / 'data'
     (MOT_results_folder).mkdir(parents=True, exist_ok=True)  # make
 
     # extend devices to as many sequences are available
@@ -200,7 +221,7 @@ def main(opt):
 
     # run the evaluation on the generated txts
     subprocess.run([
-        sys.executable,  dst_val_tools_folder / "scripts/run_mot_challenge.py",
+        sys.executable,  val_tools_target_location / "scripts/run_mot_challenge.py",
         "--BENCHMARK", opt.benchmark,
         "--TRACKERS_TO_EVAL",  opt.eval_existing if opt.eval_existing else MOT_results_folder.parent.name,
         "--SPLIT_TO_EVAL", "train",

--- a/val.py
+++ b/val.py
@@ -11,7 +11,7 @@ import zipfile
 from pathlib import Path
 import shutil
 import threading
-from tqdm import tqdm
+
 
 FILE = Path(__file__).resolve()
 ROOT = FILE.parents[0]  # yolov5 strongsort root directory
@@ -30,65 +30,52 @@ from yolov5.utils.torch_utils import select_device
 from track import run
 
 
-def download_official_mot_eval_tool(val_tools_target_location):
+def download_official_mot_eval_tool(dst_val_tools_folder):
     # source: https://github.com/JonathonLuiten/TrackEval#official-evaluation-code
     val_tools_url = "https://github.com/JonathonLuiten/TrackEval"
     try:
-        Repo.clone_from(val_tools_url, val_tools_target_location)
+        Repo.clone_from(val_tools_url, dst_val_tools_folder)
         LOGGER.info('Official MOT evaluation repo downloaded')
     except git.exc.GitError as err:
         LOGGER.info('Eval repo already downloaded')
         
-def download_mot_dataset(val_tools_target_location, benchmark):
-    
-    # download and unzip ground truth
-    url = 'https://omnomnom.vision.rwth-aachen.de/data/TrackEval/data.zip'
-    zip_dst = val_tools_target_location / 'data.zip'
-    if not zip_dst.exists():
-        LOGGER.info(f'data.zip downloaded sucessfully')
-        os.system(f"curl -# -L '{url}' -o '{zip_dst}' -# --retry 3 -C -")
-    
-    try:
-        with zipfile.ZipFile(val_tools_target_location / 'data.zip', 'r') as zip_file:
-            for member in tqdm(zip_file.namelist(), desc=f'Extracting MOT ground truth'):
-                # extract only if file has not already been extracted
-                if os.path.exists(val_tools_target_location / member) or os.path.isfile(val_tools_target_location / member):
-                    pass
-                else:
-                    zip_file.extract(member, val_tools_target_location)
-        LOGGER.info(f'data.zip unzipped sucessfully')
-    except Exception as e:
-        print('data.zip is corrupted. Try deleting the file and run the script again')
-        sys.exit()
+def download_mot_dataset(dst_val_tools_folder, benchmark):
+    import wget
+    import ssl
 
-    # download and unzip the rest of MOTXX
-    url = 'https://motchallenge.net/data/' + benchmark + '.zip'
-    zip_dst = val_tools_target_location / (benchmark + '.zip')
-    if not zip_dst.exists():
-        LOGGER.info(f'{benchmark}.zip downloaded sucessfully')
-        os.system(f"curl -# -L '{url}' -o '{zip_dst}' -# --retry 3 -C -")
-    
     try:
-        with zipfile.ZipFile((val_tools_target_location / (benchmark + '.zip')), 'r') as zip_file:
+        _create_unverified_https_context = ssl._create_unverified_context
+    except AttributeError:
+        # Legacy Python that doesn't verify HTTPS certificates by default
+        pass
+    else:
+        # Handle target environment that doesn't support HTTPS verification
+        ssl._create_default_https_context = _create_unverified_https_context
+
+    gt_data_url = 'https://omnomnom.vision.rwth-aachen.de/data/TrackEval/data.zip'
+    if not (dst_val_tools_folder / 'data').is_dir():
+        wget.download(gt_data_url, out=str(dst_val_tools_folder / 'data.zip'))
+        with zipfile.ZipFile(dst_val_tools_folder / 'data.zip', 'r') as zip_ref:
+            zip_ref.extractall(dst_val_tools_folder)
+        os.remove(dst_val_tools_folder / 'data.zip') 
+        LOGGER.info('MOTs ground truth downloaded')
+    else:
+        LOGGER.info('gt already downloaded')
+
+    mot_gt_data_url = 'https://motchallenge.net/data/' + benchmark + '.zip'
+    if not (dst_val_tools_folder / 'data' / benchmark).is_dir():
+        wget.download(mot_gt_data_url, out=str(dst_val_tools_folder / (benchmark + '.zip')))
+        with zipfile.ZipFile(dst_val_tools_folder / (benchmark + '.zip'), 'r') as zip_ref:
             if opt.benchmark == 'MOT16':
-                # extract only if file has not already been extracted
-                for member in tqdm(zip_file.namelist(), desc=f'Extracting {benchmark}'):
-                    if os.path.exists(val_tools_target_location / 'data' / 'MOT16' / member) or os.path.isfile(val_tools_target_location / 'data' / 'MOT16' / member):
-                        pass
-                    else:
-                        zip_file.extract(member, val_tools_target_location / 'data' / 'MOT16')
+                zip_ref.extractall(dst_val_tools_folder / 'data' / 'MOT16')
             else:
-                for member in tqdm(zip_file.namelist(), desc=f'Extracting {benchmark}'):
-                    if os.path.exists(val_tools_target_location / 'data' / member) or os.path.isfile(val_tools_target_location / 'data' / member):
-                        pass
-                    else:
-                        zip_file.extract(member, val_tools_target_location / 'data')
-        LOGGER.info(f'{benchmark}.zip unzipped successfully')
-    except Exception as e:
-        print(f'{benchmark}.zip is corrupted. Try deleting the file and run the script again')
-        sys.exit()
-
-
+                zip_ref.extractall(dst_val_tools_folder / 'data')
+        os.remove(dst_val_tools_folder / (benchmark + '.zip')) 
+        LOGGER.info(f'{benchmark} images downloaded')
+    else:
+        LOGGER.info(f'{benchmark} data already downloaded')
+        
+    
 def parse_opt():
     parser = argparse.ArgumentParser()
     parser.add_argument('--yolo-weights', type=str, default=WEIGHTS / 'yolov5m.pt', help='model.pt path(s)')
@@ -124,24 +111,24 @@ def main(opt):
     check_requirements(requirements=ROOT / 'requirements.txt', exclude=('tensorboard', 'thop'))
     
     # download eval files
-    val_tools_target_location = ROOT / 'val_utils'
-    download_official_mot_eval_tool(val_tools_target_location)
+    dst_val_tools_folder = ROOT / 'val_utils'
+    download_official_mot_eval_tool(dst_val_tools_folder)
     
-    if any(opt.benchmark == s for s in ['MOT16', 'MOT17', 'MOT20']):
-        download_mot_dataset(val_tools_target_location, opt.benchmark)
+    if any(opt.benchmark is s for s in ['MOT16', 'MOT17', 'MOT20']):
+        download_mot_dataset(dst_val_tools_folder, opt.benchmark)
     
     # set paths
-    mot_seqs_path = val_tools_target_location / 'data' / opt.benchmark / opt.split
+    mot_seqs_path = dst_val_tools_folder / 'data' / opt.benchmark / opt.split
     
     if opt.benchmark == 'MOT17':
         # each sequences is present 3 times, one for each detector
         # (DPM, FRCNN, SDP). Keep only sequences from  one of them
         seq_paths = sorted([str(p / 'img1') for p in Path(mot_seqs_path).iterdir() if Path(p).is_dir()])
         seq_paths = [Path(p) for p in seq_paths if 'FRCNN' in p]
-        with open(val_tools_target_location / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "r") as f:  # 
+        with open(dst_val_tools_folder / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "r") as f:  # 
             lines = f.readlines()
         # overwrite MOT17 evaluation sequences to evaluate so that they are not duplicated
-        with open(val_tools_target_location / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "w") as f:
+        with open(dst_val_tools_folder / "data/gt/mot_challenge/seqmaps/MOT17-train.txt", "w") as f:
             for line in seq_paths:
                 f.write(str(line.parent.stem) + '\n')
     else:
@@ -149,7 +136,7 @@ def main(opt):
         seq_paths = [p / 'img1' for p in Path(mot_seqs_path).iterdir() if Path(p).is_dir()]
     
     save_dir = increment_path(Path(opt.project) / opt.name, exist_ok=opt.exist_ok)  # increment run
-    MOT_results_folder = val_tools_target_location / 'data' / 'trackers' / 'mot_challenge' / Path(str(opt.benchmark) + '-' + str(opt.split)) / save_dir.name / 'data'
+    MOT_results_folder = dst_val_tools_folder / 'data' / 'trackers' / 'mot_challenge' / Path(str(opt.benchmark) + '-' + str(opt.split)) / save_dir.name / 'data'
     (MOT_results_folder).mkdir(parents=True, exist_ok=True)  # make
 
     # extend devices to as many sequences are available
@@ -213,7 +200,7 @@ def main(opt):
 
     # run the evaluation on the generated txts
     subprocess.run([
-        sys.executable,  val_tools_target_location / "scripts/run_mot_challenge.py",
+        sys.executable,  dst_val_tools_folder / "scripts/run_mot_challenge.py",
         "--BENCHMARK", opt.benchmark,
         "--TRACKERS_TO_EVAL",  opt.eval_existing if opt.eval_existing else MOT_results_folder.parent.name,
         "--SPLIT_TO_EVAL", "train",


### PR DESCRIPTION
Fixed val.py for windows.

Quote marks around the url and output file path causes parsing error on windows. Since os.system is used, it is using windows cmd to call the curl command.

Removing the quotes fixes the parsing error.

I also made the download only happen if there is an empty flag file missing called ".mot_data_downloaded". This is because I do not want to keep the 5GB zip files when they have been downloaded and unzipped (not so much storage space to work with here) and would like to have the option to remove the zip files once they are downloaded.

The flag file is created when the zip files have been successfully downloaded and extracted.