### PR TITLE
Bug Fix to show both masks and boxes at same time

### DIFF
--- a/track.py
+++ b/track.py
@@ -205,8 +205,16 @@ def run(
                 
                 # draw boxes for visualization
                 if len(outputs[i]) > 0:
+                    if save_vid and is_seg:
+                        # Mask plotting
+                        annotator.masks(
+                            masks,
+                            colors=[colors(x, True) for x in det[:, 5]],
+                            im_gpu=torch.as_tensor(im0, dtype=torch.float16).to(device).permute(2, 0, 1).flip(0).contiguous() /
+                            255 if retina_masks else im[i]
+                        )
                     for j, (output) in enumerate(outputs[i]):
-    
+                        
                         bbox = output[0:4]
                         id = output[4]
                         cls = output[5]
@@ -230,14 +238,6 @@ def run(
                                 (f'{id} {conf:.2f}' if hide_class else f'{id} {names[c]} {conf:.2f}'))
                             color = colors(c, True)
                             annotator.box_label(bbox, label, color=color)
-                            if is_seg:
-                                # Mask plotting
-                                annotator.masks(
-                                    masks,
-                                    colors=[colors(x, True) for x in det[:, 5]],
-                                    im_gpu=torch.as_tensor(im0, dtype=torch.float16).to(device).permute(2, 0, 1).flip(0).contiguous() /
-                                    255 if retina_masks else im[i]
-                                )
                             if save_trajectories and tracking_method == 'strongsort':
                                 q = output[7]
                                 tracker_list[i].trajectory(im0, q, color=color)


### PR DESCRIPTION
Bug Fix to show both masks and boxes at same time in the result video. It seems like that annotator.masks() will override the whole image, so maybe it should be placed before all of operations to draw boxes. After this change, video can show both masks and boxes at same time just like the demo shown in the README.md homepage 